### PR TITLE
修复Home.tsx的rotating text在英文状态+小屏幕下的错误渲染

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -109,19 +109,21 @@ function Home() {
                                 revealDirection="start"
                             />
                             <div className="flex items-center space-x-4">
-                                <span className="text-4xl align-middle inline-block">{t("weDevelop")}</span>
-                                <RotatingText
-                                    texts={["LauncherX", "🐱", "ConnectX", "P2P", "CMFS"]}
-                                    mainClassName="text-4xl px-3 bg-amber-400 text-black overflow-hidden py-2 rounded-lg"
-                                    staggerFrom={"last"}
-                                    initial={{ y: "100%" }}
-                                    animate={{ y: 0 }}
-                                    exit={{ y: "-120%" }}
-                                    staggerDuration={0.025}
-                                    splitLevelClassName="overflow-hidden"
-                                    transition={{ type: "spring", damping: 30, stiffness: 400 }}
-                                    rotationInterval={2000}
-                                />
+                                <span className="text-4xl align-middle inline-block whitespace-nowrap">{t("weDevelop")}</span>
+                                <div className="w-48 min-w-[8rem]">
+                                    <RotatingText
+                                        texts={["LauncherX", "🐱", "ConnectX", "P2P", "CMFS"]}
+                                        mainClassName="text-4xl px-3 bg-amber-400 text-black overflow-hidden py-2 rounded-lg"
+                                        staggerFrom={"last"}
+                                        initial={{ y: "100%" }}
+                                        animate={{ y: 0 }}
+                                        exit={{ y: "-120%" }}
+                                        staggerDuration={0.025}
+                                        splitLevelClassName="overflow-hidden"
+                                        transition={{ type: "spring", damping: 30, stiffness: 400 }}
+                                        rotationInterval={2000}
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Close #7 
### 修复内容

- 修复了首页 `Home.tsx` 中 RotatingText 组件在循环间的卸载和加载中的空缺造成的组件重排。

### 变更文件

- `src/pages/Home.tsx`

### 主要修改点

- 增加一个透明方框用于占用Rotating Text进入下一循环时的缺位，防止组件重排。
- 为 “We Develop” 字样增添 `whitespace-nowrap` 属性避免其换行。

### 测试说明

- 已在本地多分辨率下测试，未出现样式错乱。